### PR TITLE
Update allowance more frequently

### DIFF
--- a/src/RateLimiter/AbstractRateLimitProvider.php
+++ b/src/RateLimiter/AbstractRateLimitProvider.php
@@ -15,15 +15,7 @@ abstract class AbstractRateLimitProvider
      */
     public function getRoute(RequestInterface $request): string
     {
-        $route = (string) $request->getUri();
-
-        if ($request->getMethod() === 'DELETE' && strpos($route, 'messages') !== false) {
-            $route = 'DELETE-'.$route;
-        }
-
-        $stripped = $this->stripMinorParameters($route);
-
-        return $stripped;
+        return $this->stripMinorParameters((string) $request->getUri());
     }
 
     /**

--- a/src/RateLimiter/RateLimitProvider.php
+++ b/src/RateLimiter/RateLimitProvider.php
@@ -69,7 +69,7 @@ class RateLimitProvider extends AbstractRateLimitProvider
         $remaining = $response->getHeader('x-ratelimit-remaining');
         $reset = $response->getHeader('x-ratelimit-reset');
 
-        if (empty($remaining) || empty($reset) || (int) $remaining[0] > 0) {
+        if (empty($remaining) || empty($reset)) {
             return;
         }
 


### PR DESCRIPTION
Rate-limits were frequently occurring when we did not update the allowance more often.

There was also an issue where prefixing `DELETE-` to the route would result in even more rate-limits as it was not stripping any minor parameters anymore.